### PR TITLE
Add notes on serving LDAP proxy over LDAPS

### DIFF
--- a/example-proxy.ini
+++ b/example-proxy.ini
@@ -35,7 +35,10 @@ password = test
 [ldap-proxy]
 # Host and port to bind the LDAP proxy to, specified using the Twisted endpoint string syntax for servers
 # https://twistedmatrix.com/documents/16.4.1/core/howto/endpoints.html#servers
-# CAUTION: LDAPS/STARTTLS is currently unsupported!
+# CAUTION: STARTTLS is currently unsupported!
+# LDAPS can be configured using the Twisted endpoint syntax, most importantly the `privateKey` option.
+# See https://twistedmatrix.com/documents/current/core/howto/endpoints.html#servers for more information.
+#endpoint = ssl:port=1636:privateKey=/path/to/cert.pem
 endpoint = tcp:port=1389
 # List of DNs for which Bind Requests should simply be forwarded to the LDAP backend.
 # Individual DNs must be quoted and separated by a comma.

--- a/example-proxy.ini
+++ b/example-proxy.ini
@@ -20,8 +20,6 @@ instance = http://192.0.2.2
 # point to a directory containing trusted roots (only .pem files are considered!)
 #endpoint = tls:host=foo:port=636:trustRoots=/path/to/pems
 endpoint = tcp:host=192.0.2.1:port=389
-# Enabling/disabling of STARTTLS (currently unsupported)
-use-tls = false
 # If enabled, the LDAP proxy will perform an anonymous bind against the LDAP backend at startup
 # to ensure that the connection works and write a message to the log. (default is true)
 test-connection = true

--- a/pi_ldapproxy/config.py
+++ b/pi_ldapproxy/config.py
@@ -12,7 +12,7 @@ verify = boolean(default=True)
 
 [ldap-backend]
 endpoint = string
-use-tls = boolean
+use-tls = boolean(default=False)
 test-connection = boolean(default=True)
 
 [ldap-proxy]

--- a/pi_ldapproxy/proxy.py
+++ b/pi_ldapproxy/proxy.py
@@ -307,11 +307,9 @@ class ProxyServerFactory(protocol.ServerFactory):
             log.warn('privacyIDEA HTTPS certificate will NOT be checked!')
             https_policy = DisabledVerificationPolicyForHTTPS()
         self.agent = Agent(reactor, https_policy)
-        self.use_tls = config['ldap-backend']['use-tls']
-        if self.use_tls:
+        if config['ldap-backend']['use-tls']:
             # TODO: This seems to get lost if we use log.info
-            print 'LDAP over TLS is currently unsupported. Exiting.'
-            sys.exit(1)
+            log.warn('The use-tls config option is deprecated and will be ignored.')
 
         self.proxied_endpoint_string = config['ldap-backend']['endpoint']
         self.privacyidea_instance = config['privacyidea']['instance']
@@ -371,8 +369,6 @@ class ProxyServerFactory(protocol.ServerFactory):
         :return: A Deferred that fires a `LDAPClient` instance
         """
         client = yield connectToLDAPEndpoint(reactor, self.proxied_endpoint_string, LDAPClient)
-        if self.use_tls:
-            client = yield client.startTLS()
         try:
             yield client.bind(self.service_account_dn, self.service_account_password)
         except ldaperrors.LDAPException, e:
@@ -461,7 +457,6 @@ class ProxyServerFactory(protocol.ServerFactory):
                             LDAPClient)
         proto.factory = self
         proto.clientConnector = client_connector
-        proto.use_tls = self.use_tls
         return proto
 
     @defer.inlineCallbacks


### PR DESCRIPTION
This deprecates the confusing ``use-tls`` option. I think this is no problem, as it was set to ``false`` in the example config file, and the LDAP proxy would abort if it is set to ``true``.

Apart from that, it seems like Twisted supports serving TLS out-of-the-box if we use the correct server endpoint syntax. So this just adds a note in the example config file.

Working on #3.